### PR TITLE
MA-181 Fix Grafana dashboard

### DIFF
--- a/promplus/grafana-dashboard-cluster-explorer
+++ b/promplus/grafana-dashboard-cluster-explorer
@@ -1626,7 +1626,7 @@
         "multiFormat": "regex values",
         "name": "host",
         "options": [],
-        "query": "label_values($tag)",
+        "query": "label_values(node_uname_info, instance)",
         "refresh": 1,
         "refresh_on_load": false,
         "regex": "",
@@ -1638,31 +1638,14 @@
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
-          "tags": [],
-          "text": "alias",
-          "value": "alias"
+          "text": "instance",
+          "value": "instance"
         },
-        "hide": 0,
-        "includeAll": false,
-        "label": null,
+        "hide": 2,
         "multi": false,
         "name": "tag",
-        "options": [
-          {
-            "selected": false,
-            "text": "instance",
-            "value": "instance"
-          },
-          {
-            "selected": true,
-            "text": "alias",
-            "value": "alias"
-          }
-        ],
-        "query": "instance, alias",
-        "type": "custom"
+        "type": "constant"
       }
     ]
   },


### PR DESCRIPTION

## ISSUE(S):
[MA-181](https://platform9.atlassian.net/browse/MA-181): Grafana UI showing an internal docker IP in hosts list

## SUMMARY
- Grafana UI currently lists an internal docker IP in the list of hosts.
- Removed unwanted docker IP, and UI shows only the IP of connected hosts.
- Remove tag field which is not required and can cause confusion to the end user.

## ISSUE TYPE
<!--- Please delete options that are not relevant. -->
<!--- This can be updated interactively by clicking check-boxes once the description is posted -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## DEPENDS ON:
https://platform9.atlassian.net/browse/MA-181

## TESTING DONE
Tested on a Decco DU. Grafana UI shows the appropriate updated changes.