### PR TITLE
AIR-923 Upgrades to resolve security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ COPY promplus /etc/promplus/
 
 RUN chmod +x /bin/promplus
 
+RUN apk add libc6-compat
+
 ENTRYPOINT [ "/bin/promplus" ]

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ pkg=cmd/main.go
 go_cmd=go
 repo=platform9
 image_name=monhelper
+version=v2.0.2
+GOPATH=$(shell go env GOPATH)
+TAG?=${repo}/${image_name}:${version}
+
+SRC_ROOT=$(abspath $(dir $(lastword $(MAKEFILE_LIST)))/)
+BUILD_ROOT = $(SRC_ROOT)/build
 
 .PHONY: all
 all: test binary
@@ -17,6 +23,11 @@ clean:
 ${build_dir}:
 	mkdir -p ${build_dir}
 	mkdir -p ${bin_dir}
+	mkdir -p ${GOPATH}/src
+	cp -r vendor/*  ${GOPATH}/src
+	mkdir -p ${GOPATH}/src/github.com/platform9/prometheus-plus
+	cp -r ./* ${GOPATH}/src/github.com/platform9/prometheus-plus/
+	rm -rf ${GOPATH}/src/github.com/platform9/prometheus-plus/vendor
 
 binary: ${build_dir}
 	${go_cmd} build -o ${bin_dir}/${prog_name} ${pkg}
@@ -26,5 +37,14 @@ test:
 
 image: go_cmd = GOOS=linux GOARCH=amd64 go
 image: binary
-	docker build -t ${repo}/${image_name} .
+	docker build -t ${TAG} .
+
+push: 
+	docker push $(TAG) \
+	&& docker rmi $(TAG)
+
+scan: 
+	mkdir -p $(BUILD_ROOT)/monhelper
+	docker run -v $(BUILD_ROOT)/monhelper:/out -v /var/run/docker.sock:/var/run/docker.sock  aquasec/trivy image -s CRITICAL,HIGH -f json  --vuln-type library -o /out/library_vulnerabilities.json --exit-code 22 ${TAG}
+	docker run -v $(BUILD_ROOT)/monhelper:/out -v /var/run/docker.sock:/var/run/docker.sock  aquasec/trivy image -s CRITICAL,HIGH -f json  --vuln-type os -o /out/os_vulnerabilities.json --exit-code 22 ${TAG}
 


### PR DESCRIPTION
## ISSUE(S):
[AIR-512](https://platform9.atlassian.net/jira/software/c/projects/AIR/boards/116?modal=detail&selectedIssue=AIR-512)

## SUMMARY:
Trivy scan on the image `platform9/monhelper:v2.0.1` gives OS related vulnerabilities ( 6 HIGH, 1 CRITICAL) due to `alpine:3.15`, hence upgraded to `alpine:3.16`. 

Built the image locally, running a trivy scan shows that it has no vulnerabilities.

Related to the PR: https://github.com/platform9/pf9-addon-operator/pull/189

[AIR-512]: https://platform9.atlassian.net/browse/AIR-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ